### PR TITLE
Update: add tag JSON format for schedules in drug requests

### DIFF
--- a/drugapi/src/main/java/com/mahidol/drugapi/drug/dtos/request/CreateDrugRequest.java
+++ b/drugapi/src/main/java/com/mahidol/drugapi/drug/dtos/request/CreateDrugRequest.java
@@ -1,5 +1,6 @@
 package com.mahidol.drugapi.drug.dtos.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -43,6 +44,7 @@ public class CreateDrugRequest {
     @Max(value = 3, message = "Invalid usage time")
     private int usageTime;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private List<LocalTime> schedules;
 
     private Boolean isInternalDrug;

--- a/drugapi/src/main/java/com/mahidol/drugapi/drug/dtos/request/UpdateDrugRequest.java
+++ b/drugapi/src/main/java/com/mahidol/drugapi/drug/dtos/request/UpdateDrugRequest.java
@@ -1,5 +1,6 @@
 package com.mahidol.drugapi.drug.dtos.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -40,6 +41,7 @@ public class UpdateDrugRequest {
     @Max(value = 3, message = "Invalid usage time")
     private Integer usageTime;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private List<LocalTime> schedules;
 
     private Boolean isEnabled;

--- a/drugapi/src/main/java/com/mahidol/drugapi/druggroup/dtos/request/CreateGroupRequest.java
+++ b/drugapi/src/main/java/com/mahidol/drugapi/druggroup/dtos/request/CreateGroupRequest.java
@@ -1,5 +1,6 @@
 package com.mahidol.drugapi.druggroup.dtos.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -22,6 +23,7 @@ public class CreateGroupRequest {
     private String groupName;
 
     @NotNull(message = "schedules should not be null")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private List<LocalTime> schedules;
 
     @NotNull(message = "drugs should not be null")


### PR DESCRIPTION
Add the tag so that the backend can receive string-type data and convert it to LocalTime since the frontend does not have a variable of the type LocalTime like the backend.